### PR TITLE
Add project gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ======================================
-# 🐍 Python standard .gitignore
+# 🐍 Python / PyTest API framework
 # ======================================
 
 # Byte-compiled / optimized / DLL files
@@ -7,12 +7,24 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# C extensions
+*.so
+
 # Virtual environments
 .venv/
 venv/
 env/
 ENV/
+
+# Environment variables and local secrets
+.env
+.env.*
+!.env.example
+*.local
+
+# Dependency / lock files generated locally
 Pipfile.lock
+poetry.lock
 
 # Distribution / packaging
 build/
@@ -31,10 +43,9 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
-#  Files created by PyInstaller
-#  Usually contain a manifest and other build data
 *.manifest
 *.spec
 
@@ -56,50 +67,54 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit*.xml
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff
-instance/
-.webassets-cache
-
-# Scrapy stuff
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-build/
-temp/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# VSCode and other IDEs
-.vscode/
-.idea/
-*.swp
-*.swo
-*.bak
-
-# macOS / Linux
-.DS_Store
-Thumbs.db
+# Test and API automation reports
+reports/
+allure-results/
+allure-report/
+report.html
+pytest-report.html
 
 # Logs
 logs/
 *.log
 
+# Generated test/output artifacts
+# Existing tracked examples stay versioned; this ignores newly generated local files.
+generated/*
+!generated/.gitkeep
+
+# Translations
+*.mo
+*.pot
+
+# Framework-specific runtime data
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+instance/
+.webassets-cache
+.scrapy
+
+# Documentation build output
+docs/_build/
+
 # Temporary files
 tmp/
 temp/
+*.tmp
+*.bak
+*.swp
+*.swo
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# IDE/editor metadata
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
### Motivation
- Prevent committing local and generated artifacts from a Python/PyTest API framework into the repository by providing a comprehensive `.gitignore` tailored to the project.
- Cover common Python caches, virtualenvs, packaging artifacts, test/coverage/report outputs, logs, and editor/OS metadata to keep the tree clean.
- Preserve intentional tracked examples and templates such as `!.env.example` and `!generated/.gitkeep` while ignoring new local/generated files.

### Description
- Rewrote and expanded the `.gitignore` header and rules to target Python/PyTest workflows and project-specific outputs. 
- Added rules for virtual environments, C extensions (`*.so`), local secrets (`.env`, `.env.*`), dependency lockfiles (`Pipfile.lock`, `poetry.lock`), and packaging artifacts (`MANIFEST`, `dist/`, `build/`).
- Added test/report/coverage ignores including `junit*.xml`, `reports/`, `allure-results/`, `allure-report/`, `report.html`, `pytest-report.html`, and ` .pytest_cache/` entries. 
- Added ignores for `logs/`, generated outputs with `generated/*` while keeping `!generated/.gitkeep`, documentation output (`docs/_build/`), temporary files (`tmp/`, `*.tmp`, `*.swp`), IDE metadata (`.vscode/`, `.idea/`), and OS files (`.DS_Store`, `Thumbs.db`).

### Testing
- Ran `git check-ignore .env logs/app.log reports/report.html generated/new_test.py .pytest_cache/cache` to confirm the listed local artifacts are ignored, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b130f3a88323b96087ff4d30deae)