### PR TITLE
docs: add online publishing workflow and update README/CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,108 @@
-🤝 Contributing Guidelines
-🇮🇹 Come contribuire al progetto AI Test Case Generator
-🇬🇧 How to contribute to the AI Test Case Generator project
+# 🤝 Contributing Guidelines
 
-🧭 Overview
-🇮🇹 Questo progetto è open source e accoglie con piacere contributi di ogni tipo:
-bug fix, nuove feature, miglioramenti alla documentazione o feedback sui test.
+🇮🇹 Come contribuire al progetto **AI Test Case Generator**.
+🇬🇧 How to contribute to the **AI Test Case Generator** project.
 
-🇬🇧 This project is open source and welcomes all kinds of contributions:
-bug fixes, new features, documentation improvements, or test feedback.
+---
 
-⚙️ Prerequisiti / Prerequisites
-Python 3.8+
-pytest per i test automatizzati
-Familiarità con git e GitHub pull requests
-(Opzionale) Chiave API OpenAI per test avanzati
-🔧 Setup Ambiente / Environment Setup
-🇮🇹 Per contribuire, prima crea un ambiente virtuale e installa le dipendenze:
-🇬🇧 To contribute, first create a virtual environment and install dependencies:
+## 🧭 Overview
 
-git clone https://github.com/your-username/ai-testcase-generator.git
+🇮🇹 Questo progetto è open source e accoglie contributi di ogni tipo: bug fix, nuove feature, miglioramenti alla documentazione o feedback sui test.
+
+🇬🇧 This project is open source and welcomes all kinds of contributions: bug fixes, new features, documentation improvements, or test feedback.
+
+---
+
+## ⚙️ Prerequisiti / Prerequisites
+
+- Python 3.8+
+- `pytest` per i test automatizzati
+- Familiarità con Git e GitHub Pull Requests
+- Opzionale: chiave API OpenAI per test avanzati con provider `openai`
+
+---
+
+## 🔧 Setup ambiente / Environment setup
+
+```bash
+git clone https://github.com/<tuo-utente>/ai-testcase-generator.git
 cd ai-testcase-generator
 
 python -m venv .venv
 source .venv/bin/activate        # Windows: .venv\Scripts\Activate.ps1
 
 pip install -r requirements.txt
+```
+
+---
+
+## 🌿 Branch workflow
+
+🇮🇹 Non lavorare direttamente su `main`. Crea un branch per ogni modifica.
+🇬🇧 Do not work directly on `main`. Create a branch for each change.
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/<nome-feature>
+```
+
+Esempi:
+
+- `feature/add-web-demo`
+- `feature/update-docs`
+- `fix/excel-loader`
+- `release/v1.1.0`
+
+Per una guida completa su branch, PR e pubblicazione online, consulta [`docs/online_release_workflow.md`](docs/online_release_workflow.md).
+
+---
+
+## ✅ Test prima della Pull Request
+
+Esegui almeno questi controlli:
+
+```bash
+pytest
+python -m ai_tc_gen.cli generate --spec examples/specs/sample_spec.yaml --provider local --out generated
+```
+
+---
+
+## 📬 Pull Request
+
+Prima di aprire una PR:
+
+1. Verifica che il branch sia aggiornato con `main`.
+2. Esegui i test.
+3. Aggiorna la documentazione se cambia il comportamento del progetto.
+4. Scrivi una descrizione chiara della modifica.
+
+Esempio:
+
+```bash
+git status
+git add .
+git commit -m "docs: update online publishing workflow"
+git push -u origin feature/update-docs
+```
+
+Poi apri una Pull Request su GitHub verso `main`.
+
+---
+
+## 🔐 Sicurezza
+
+Non committare mai:
+
+- file `.env`
+- chiavi API
+- password
+- token personali
+- dati sensibili o file generati con informazioni private
+
+Prima di pubblicare online, puoi fare un controllo rapido:
+
+```bash
+rg -n "OPENAI_API_KEY|api_key|secret|password|token|\.env" .
+```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # 🧪 AI Test Case Generator
 
-🇮🇹 Generatore di test case automatizzati basato su specifiche YAML o Excel.  
+🇮🇹 Generatore di test case automatizzati basato su specifiche YAML o Excel.
 🇬🇧 Automated test case generator based on YAML or Excel specifications.
 
 ---
 
 ## 🚀 Funzionalità / Features
 
-- ✅ Input da file **YAML** o **Excel (.xlsx)**  
-- 🧠 Supporto a test case generati tramite AI o provider locali  
-- ⚙️ Output in formato leggibile (Markdown o JSON)  
-- 🔍 Logging e validazione automatica delle specifiche  
+- ✅ Input da file **YAML** o **Excel (.xlsx)**
+- 🧠 Supporto a test case generati tramite AI o provider locali
+- ⚙️ Output in formato leggibile per test `pytest`
+- 🔍 Logging e validazione automatica delle specifiche
 - 📦 Compatibile con ambienti Windows, Linux e macOS
+- 🌐 Documentazione pronta per pubblicazione online e portfolio
 
 ---
 
@@ -20,8 +21,53 @@
 ```bash
 git clone https://github.com/<tuo-utente>/ai-testcase-generator.git
 cd ai-testcase-generator
+python -m venv .venv
+source .venv/bin/activate      # Windows: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
+```
+
+---
+
+## ▶️ Uso rapido / Quick Start
+
+```bash
+python -m ai_tc_gen.cli generate \
+  --spec examples/specs/sample_spec.yaml \
+  --provider local \
+  --out generated
+
+pytest generated/
+```
+
+Il file generato sarà salvato nella cartella `generated/`.
+
+---
+
+## 🌿 Branch e pubblicazione online
+
+Per rendere il progetto disponibile online in modo ordinato:
+
+1. Lavora su un branch dedicato, ad esempio `feature/update-readme`.
+2. Esegui test e generazione di esempio in locale.
+3. Apri una Pull Request verso `main`.
+4. Dopo il merge, pubblica una release GitHub con un tag come `v1.0.0`.
+
+Consulta la guida completa: [docs/online_release_workflow.md](docs/online_release_workflow.md).
+
+---
 
 ## 🧭 Project Status
-✅ v1.0.0 – CLI core version released  
-🚧 v2.0.0 – Web App version in development
+
+- ✅ `v1.0.0` – CLI core version released
+- 🚧 `v2.0.0` – Web App version in development
+
+---
+
+## 📚 Documentazione / Documentation
+
+- [How to run](HOW_TO_RUN.md)
+- [Windows guide](HOW_TO_RUN_WINDOWS.md)
+- [How to use](docs/how_to_use.md)
+- [Excel input guide](docs/excelversion.md)
+- [Online publishing workflow](docs/online_release_workflow.md)
+- [Contributing](CONTRIBUTING.md)

--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -1,21 +1,21 @@
 # 🚀 How to Use the AI Test Case Generator
 
-🇮🇹 *Guida rapida all’utilizzo del generatore di test automatico*  
+🇮🇹 *Guida rapida all’utilizzo del generatore di test automatico*
 🇬🇧 *Quick guide for using the automatic test generator*
 
 ---
 
 ## 🧭 Overview
 
-🇮🇹 Il tool genera casi di test (`pytest`) partendo da specifiche in YAML o Excel.  
+🇮🇹 Il tool genera casi di test (`pytest`) partendo da specifiche in YAML o Excel.
 🇬🇧 The tool generates `pytest` test cases based on YAML or Excel specifications.
 
 ---
 
 ## 🧰 Prerequisiti / Prerequisites
 
-- Python ≥ 3.8  
-- Virtual environment (recommended)  
+- Python ≥ 3.8
+- Virtual environment (recommended)
 - Packages: `jinja2`, `pyyaml`, `pandas`, `openpyxl`, `pytest`
 
 Install dependencies:
@@ -30,7 +30,7 @@ pip install -r requirements.txt
 
 ### 🧾 YAML Input
 
-🇮🇹 Per generare test da un file YAML:  
+🇮🇹 Per generare test da un file YAML:
 🇬🇧 To generate tests from a YAML file:
 
 ```bash
@@ -39,7 +39,7 @@ python -m ai_tc_gen.cli generate --spec examples/specs/sample_spec.yaml --provid
 
 ### 📊 Excel Input
 
-🇮🇹 Per generare test da un file Excel (.xlsx):  
+🇮🇹 Per generare test da un file Excel (.xlsx):
 🇬🇧 To generate tests from an Excel file (.xlsx):
 
 ```bash
@@ -59,7 +59,7 @@ python -m ai_tc_gen.cli generate --spec-excel spec.xlsx --provider local --out g
 
 ## 📁 Output
 
-🇮🇹 I test vengono salvati in `generated/` come file `.py`.  
+🇮🇹 I test vengono salvati in `generated/` come file `.py`.
 🇬🇧 Tests are saved under `generated/` as `.py` files.
 
 Example:
@@ -71,7 +71,7 @@ generated/test_create_order.py
 
 ## 🧪 Eseguire i test / Run Tests
 
-🇮🇹 Dopo la generazione, puoi eseguirli con:  
+🇮🇹 Dopo la generazione, puoi eseguirli con:
 🇬🇧 After generation, run them using:
 
 ```bash
@@ -82,10 +82,10 @@ pytest generated/
 
 ## ⚠️ Suggerimenti / Tips
 
-- 🇮🇹 Usa `--out` per specificare una directory di output diversa.  
-- 🇬🇧 Use `--out` to specify a different output directory.  
-- 🇮🇹 Per usare OpenAI, imposta la variabile `OPENAI_API_KEY`.  
-- 🇬🇧 To use OpenAI, set the `OPENAI_API_KEY` environment variable.  
+- 🇮🇹 Usa `--out` per specificare una directory di output diversa.
+- 🇬🇧 Use `--out` to specify a different output directory.
+- 🇮🇹 Per usare OpenAI, imposta la variabile `OPENAI_API_KEY`.
+- 🇬🇧 To use OpenAI, set the `OPENAI_API_KEY` environment variable.
 
 ---
 
@@ -110,6 +110,7 @@ pytest generated/
 
 ## 📘 Additional Docs
 
-- [versioneExcel.md](versioneExcel.md) — Excel Input Guide  
-- [HOW_TO_RUN_WINDOWS.md](../HOW_TO_RUN_WINDOWS.md) — Windows execution steps  
+- [excelversion.md](excelversion.md) — Excel Input Guide
+- [online_release_workflow.md](online_release_workflow.md) — Branch, Pull Request, online publishing and release workflow
+- [HOW_TO_RUN_WINDOWS.md](../HOW_TO_RUN_WINDOWS.md) — Windows execution steps
 - [README.md](../README.md) — Project overview

--- a/docs/online_release_workflow.md
+++ b/docs/online_release_workflow.md
@@ -1,0 +1,276 @@
+# 🌐 Guida passo/passo: branch, pubblicazione online e release
+
+Questa guida spiega come usare i branch Git in modo ordinato e come rendere il progetto **AI Test Case Generator** disponibile online per portfolio, collaborazione e download.
+
+> Obiettivo consigliato: repository pubblico su GitHub, documentazione leggibile dal README, workflow CI attivo e release versionata.
+
+---
+
+## 1. Scegli il flusso di branch
+
+Usa pochi branch con ruoli chiari:
+
+| Branch | Scopo | Quando usarlo |
+| --- | --- | --- |
+| `main` | Versione stabile e pubblicabile | Solo codice già verificato |
+| `develop` | Integrazione delle modifiche prima della release | Facoltativo, utile se lavori su molte feature |
+| `feature/<nome>` | Nuove funzionalità o documentazione | Per ogni modifica isolata |
+| `fix/<nome>` | Correzioni bug | Quando devi sistemare un problema |
+| `release/<versione>` | Preparazione release | Prima di pubblicare una versione |
+
+Per un progetto personale o portfolio puoi anche usare un flusso semplice:
+
+```bash
+main
+└── feature/documentazione-online
+└── feature/web-app
+└── fix/cli-excel
+```
+
+---
+
+## 2. Prepara il repository locale
+
+```bash
+# Clona il repository
+git clone https://github.com/<tuo-utente>/ai-testcase-generator.git
+cd ai-testcase-generator
+
+# Controlla branch e stato
+git branch
+git status
+```
+
+Se parti da un progetto locale non ancora su GitHub:
+
+```bash
+git init
+git add .
+git commit -m "Initial project setup"
+git branch -M main
+git remote add origin https://github.com/<tuo-utente>/ai-testcase-generator.git
+git push -u origin main
+```
+
+---
+
+## 3. Crea un branch per ogni modifica
+
+Non lavorare direttamente su `main`.
+
+```bash
+# Aggiorna main
+git checkout main
+git pull origin main
+
+# Crea un branch descrittivo
+git checkout -b feature/update-online-docs
+```
+
+Esempi di nomi utili:
+
+```bash
+feature/add-streamlit-ui
+feature/update-readme
+feature/github-actions
+fix/excel-generation
+release/v1.1.0
+```
+
+---
+
+## 4. Lavora, testa e salva le modifiche
+
+Installa le dipendenze e verifica che il progetto funzioni:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate      # Windows: .venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pytest
+```
+
+Genera un esempio locale:
+
+```bash
+python -m ai_tc_gen.cli generate \
+  --spec examples/specs/sample_spec.yaml \
+  --provider local \
+  --out generated
+```
+
+Poi committa:
+
+```bash
+git status
+git add README.md CONTRIBUTING.md docs/online_release_workflow.md
+git commit -m "docs: add online publishing workflow"
+git push -u origin feature/update-online-docs
+```
+
+---
+
+## 5. Apri una Pull Request
+
+Su GitHub:
+
+1. Vai nel repository.
+2. Clicca **Compare & pull request**.
+3. Seleziona:
+   - base: `main`
+   - compare: `feature/update-online-docs`
+4. Scrivi cosa è cambiato.
+5. Controlla che i test automatici passino.
+6. Fai merge solo quando la PR è pronta.
+
+Dopo il merge, aggiorna il repository locale:
+
+```bash
+git checkout main
+git pull origin main
+git branch -d feature/update-online-docs
+```
+
+---
+
+## 6. Rendi il progetto disponibile online su GitHub
+
+Checklist minima per un repository pubblico professionale:
+
+- `README.md` con descrizione, installazione, uso e screenshot/output di esempio.
+- `requirements.txt` aggiornato.
+- `LICENSE` presente.
+- `CONTRIBUTING.md` con regole di contribuzione.
+- `SECURITY.md` per segnalazioni di sicurezza.
+- Workflow CI in GitHub Actions.
+- Tag/release per versioni stabili.
+
+Se vuoi renderlo pubblico:
+
+1. Apri GitHub → repository → **Settings**.
+2. Vai in **General** → **Danger Zone**.
+3. Usa **Change repository visibility**.
+4. Seleziona **Public**.
+5. Verifica che non ci siano segreti, token o file `.env` nel repository.
+
+Prima di pubblicare, cerca possibili segreti:
+
+```bash
+git status
+rg -n "OPENAI_API_KEY|api_key|secret|password|token|\.env" .
+```
+
+---
+
+## 7. Pubblica una release versionata
+
+Quando `main` è stabile:
+
+```bash
+git checkout main
+git pull origin main
+pytest
+
+git tag -a v1.0.0 -m "Release v1.0.0"
+git push origin v1.0.0
+```
+
+Poi su GitHub:
+
+1. Vai in **Releases**.
+2. Clicca **Draft a new release**.
+3. Seleziona il tag `v1.0.0`.
+4. Scrivi changelog, istruzioni di installazione e comandi rapidi.
+5. Pubblica la release.
+
+Esempio di changelog:
+
+```md
+## v1.0.0
+
+### Added
+- CLI per generare test case da YAML.
+- Provider locale deterministico.
+- Documentazione iniziale.
+
+### Verified
+- Test eseguiti con pytest.
+```
+
+---
+
+## 8. Opzioni per una demo online
+
+Questo progetto è principalmente una CLI Python. Per renderlo “provabile online”, scegli una di queste strade:
+
+### Opzione A — Repository GitHub pubblico
+
+È la scelta più semplice e consigliata per portfolio. Gli utenti clonano il progetto e lo eseguono localmente.
+
+### Opzione B — GitHub Codespaces
+
+Aggiungi istruzioni nel README per aprire il progetto in Codespaces. È utile perché l’utente può provarlo nel browser senza configurare Python sul proprio PC.
+
+### Opzione C — Web app dimostrativa
+
+Se vuoi una vera interfaccia online, crea un branch dedicato:
+
+```bash
+git checkout -b feature/web-demo
+```
+
+Poi aggiungi una UI con un framework leggero come Streamlit o Flask. La UI dovrebbe permettere di:
+
+1. Caricare un file YAML o Excel.
+2. Scegliere provider `local` o `openai`.
+3. Generare il test.
+4. Scaricare il file generato.
+
+Possibili piattaforme di deploy:
+
+- Streamlit Community Cloud, se scegli Streamlit.
+- Render, Railway o Fly.io, se scegli Flask/FastAPI.
+- GitHub Pages solo per documentazione statica, non per eseguire Python backend.
+
+---
+
+## 9. Workflow consigliato per le prossime evoluzioni
+
+```bash
+# 1. Parto sempre da main aggiornato
+git checkout main
+git pull origin main
+
+# 2. Creo un branch mirato
+git checkout -b feature/<nome-feature>
+
+# 3. Modifico codice o documentazione
+
+# 4. Eseguo controlli
+pytest
+python -m ai_tc_gen.cli generate --spec examples/specs/sample_spec.yaml --provider local --out generated
+
+# 5. Commit e push
+git add .
+git commit -m "feat: descrizione breve"
+git push -u origin feature/<nome-feature>
+
+# 6. Apro PR verso main
+
+# 7. Dopo merge, creo tag se è una release
+git checkout main
+git pull origin main
+git tag -a v1.1.0 -m "Release v1.1.0"
+git push origin v1.1.0
+```
+
+---
+
+## 10. Regole pratiche per evitare problemi
+
+- Non committare `.env`, chiavi API o password.
+- Usa branch piccoli e facili da revisionare.
+- Scrivi messaggi di commit chiari: `docs:`, `feat:`, `fix:`, `test:`.
+- Prima di aprire una PR, esegui sempre `pytest`.
+- Aggiorna il README quando cambia il modo di installare o usare il progetto.
+- Usa tag semantici: `v1.0.0`, `v1.1.0`, `v2.0.0`.


### PR DESCRIPTION
### Motivation
- Provide a clear step-by-step workflow for using Git branches, opening Pull Requests, publishing the repository on GitHub and creating releases so the project can be published online and used as a portfolio/demo.  
- Surface the workflow in top-level docs so contributors and maintainers can follow a repeatable release and demo process.

### Description
- Added a new file `docs/online_release_workflow.md` containing a guided workflow for branches, local setup, PRs, publishing, releases and demo options.  
- Updated `README.md` with a more complete quick-start (venv instructions), a link to the new publishing workflow, and a consolidated documentation list.  
- Rewrote and expanded `CONTRIBUTING.md` to include environment setup, branch naming, PR checks and security reminders.  
- Updated `docs/how_to_use.md` to correct the Excel guide link and include a reference to the new publishing workflow, and applied minor formatting/whitespace fixes across edited docs.

### Testing
- Ran `git diff --check` and fixed trailing whitespace issues, and the check passed after cleanup.  
- Ran the test suite with `python -m pytest` and all tests passed (`1 passed`).  
- Exercised the CLI with `python -m ai_tc_gen.cli generate --spec examples/specs/sample_spec.yaml --provider local --out /tmp/ai-tc-gen-doc-check` and it successfully generated the expected test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bbf48a1c8323bc41603dff38a645)